### PR TITLE
Adding support for comments in vim syntax

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -32,5 +32,5 @@ highlight link    swiftConstant       String
 
 highlight link    swiftString         String
 highlight link    swiftExpression     Identifier
-highlight link    SwiftComment        Keyword
+highlight link    SwiftComment        Normal
 

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -21,6 +21,7 @@ syntax  match     swiftConstant     "let\s\zs\w*"
 syntax  region    swiftString       start=\"\ end=\"\
 syntax  region    swiftExpression   start="\\(\zs" end="\ze)" containedin=swiftString
 syntax  region    swiftComment      start="//" end="\n"
+syntax  region    swiftComment      start="/\*" end="\*/"
 
 highlight link    swiftKeyword        Keyword
 highlight link    swiftType           Type

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -20,6 +20,7 @@ syntax  match     swiftConstant     "let\s\zs\w*"
 
 syntax  region    swiftString       start=\"\ end=\"\
 syntax  region    swiftExpression   start="\\(\zs" end="\ze)" containedin=swiftString
+syntax  region    swiftComment      start="//" end="\n"
 
 highlight link    swiftKeyword        Keyword
 highlight link    swiftType           Type
@@ -31,4 +32,5 @@ highlight link    swiftConstant       String
 
 highlight link    swiftString         String
 highlight link    swiftExpression     Identifier
+highlight link    SwiftComment        Keyword
 


### PR DESCRIPTION
Currently, it highlights the comment the same as it would normal text. 
This supports both multiline & single-line comments. 